### PR TITLE
Increase NOFILE and NPROC limits

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+lxd (0.14-0ubuntu2) wily; urgency=medium
+
+  * Cherry-pick bugfix for invalid / permission when using split-images.
+    5f45bfb2032716259be2412e0ac0902d70b944f0
+
+ -- Stéphane Graber <stgraber@ubuntu.com>  Sun, 26 Jul 2015 15:23:06 +0200
+
 lxd (0.14-0ubuntu1) wily; urgency=medium
 
   * New upstream release (0.14)


### PR DESCRIPTION
Increase NOFILE and NPROC limits
Increasing the max number of files and processes. It seems containers inherit these max values.

Otherwise, the following is not possible

    adduser foo
    echo "foo             hard    nproc           32768" >> /etc/security/limits.conf
    su - foo

Without the change, su will fail with the error "could not open session" because it is trying to increase nproc above the max.

Signed-off-by: Ragnar Rova <ragnar.rova@gmail.com>