### PR TITLE
lxd-startup.service: drop dependency on lxc.service

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+lxd (0.20-0ubuntu5) UNRELEASED; urgency=medium
+
+  * lxd-startup.service: drop dependency on lxc.service.  That's only
+    needed by full lxd.
+
+ -- Serge Hallyn <serge.hallyn@ubuntu.com>  Sat, 24 Oct 2015 20:11:21 -0500
+
 lxd (0.20-0ubuntu4) wily; urgency=medium
 
   * Use dh-golang. (LP: #1481507)

--- a/debian/lxd-startup.service
+++ b/debian/lxd-startup.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Container hypervisor based on LXC - boot time check
-After=cgmanager.service lxc.service lxd-unix.socket
-Requires=cgmanager.service lxc.service lxd-unix.socket
+After=cgmanager.service lxd-unix.socket
+Requires=cgmanager.service lxd-unix.socket
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
That's only needed by full lxd.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>