### PR TITLE
lxd-startup.service: drop lxc and cgmanager dependencies

### DIFF
--- a/debian/lxd-startup.service
+++ b/debian/lxd-startup.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Container hypervisor based on LXC - boot time check
-After=cgmanager.service lxc.service lxd-unix.socket
-Requires=cgmanager.service lxc.service lxd-unix.socket
+After=lxd-unix.socket
+Requires=lxd-unix.socket
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The lxc.service dep was already dropped in wily branch, but not xenial.
In that commit, stgraber mentioned we should drop cgmanager dep as well.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>