### PR TITLE
Add remote-fs as requirement for lxd startups (for example for CephFS).

### DIFF
--- a/debian/lxd.lxd-containers.service
+++ b/debian/lxd.lxd-containers.service
@@ -2,7 +2,7 @@
 Description=LXD - container startup/shutdown
 Documentation=man:lxd(1)
 After=lxd.socket lxd.service
-Requires=lxd.socket
+Requires=lxd.socket remote-fs.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Signed-off-by: Rene Jochum <rene@jochums.at>