### PR TITLE
Proper handling for WSL upgrade

### DIFF
--- a/debian/lxd.preinst
+++ b/debian/lxd.preinst
@@ -23,12 +23,12 @@ case "$1" in
         COUNT=0
         SKIP=false
         while :; do
-            if [ ! -e "/run/snapd.socket" ] && [ ! -e "/var/lib/lxd/server.crt" ] \ 
-                || [ ! -e "/run/snapd.socket" ] \
-                && [ ! "$(ls -A /var/lib/lxd/containers)" ] \
-                && [ ! "$(ls -A /var/lib/lxd/images)" ] \
-                && [ ! "$(ls -A /var/lib/lxd/networks)" ] \
-                && [ ! "$(ls -A /var/lib/lxd/storage-pools)" ]
+            if ( [ ! -e "/run/snapd.socket" ] && [ ! -e "/var/lib/lxd/server.crt" ] ) \
+                || ( [ ! -e "/run/snapd.socket" ] \
+                && [ -z "$(ls -A /var/lib/lxd/containers)" ] \
+                && [ -z "$(ls -A /var/lib/lxd/images)" ] \
+                && [ -z "$(ls -A /var/lib/lxd/networks)" ] \
+                && [ -z "$(ls -A /var/lib/lxd/storage-pools)" ] )
             then
                 echo "===> System doesn't have working snapd and LXD was never used, skipping"
                 SKIP=true

--- a/debian/lxd.preinst
+++ b/debian/lxd.preinst
@@ -23,6 +23,12 @@ case "$1" in
         COUNT=0
         SKIP=false
         while :; do
+            if [ -f /proc/sys/fs/binfmt_misc/WSLInterop ]; then
+                echo "===> WSL detected; Skipping migration"
+                SKIP=true
+                break
+            fi
+
             snap info lxd >/dev/null 2>&1 && break
 
             db_fset lxd/snap-no-connectivity seen false

--- a/debian/lxd.preinst
+++ b/debian/lxd.preinst
@@ -25,10 +25,10 @@ case "$1" in
         while :; do
             if ( [ ! -e "/run/snapd.socket" ] && [ ! -e "/var/lib/lxd/server.crt" ] ) \
                 || ( [ ! -e "/run/snapd.socket" ] \
-                && [ -z "$(ls -A /var/lib/lxd/containers)" ] \
-                && [ -z "$(ls -A /var/lib/lxd/images)" ] \
-                && [ -z "$(ls -A /var/lib/lxd/networks)" ] \
-                && [ -z "$(ls -A /var/lib/lxd/storage-pools)" ] )
+                && [ -z "$(ls -A /var/lib/lxd/containers >/dev/null 2>&1)" ] \
+                && [ -z "$(ls -A /var/lib/lxd/images >/dev/null 2>&1)" ] \
+                && [ -z "$(ls -A /var/lib/lxd/networks >/dev/null 2>&1)" ] \
+                && [ -z "$(ls -A /var/lib/lxd/storage-pools >/dev/null 2>&1)" ] )
             then
                 echo "===> System doesn't have working snapd and LXD was never used, skipping"
                 SKIP=true

--- a/debian/lxd.preinst
+++ b/debian/lxd.preinst
@@ -23,8 +23,14 @@ case "$1" in
         COUNT=0
         SKIP=false
         while :; do
-            if [ -f /proc/sys/fs/binfmt_misc/WSLInterop ]; then
-                echo "===> WSL detected; Skipping migration"
+            if [ ! -e "/run/snapd.socket" ] && [ ! -e "/var/lib/lxd/server.crt" ] \ 
+                || [ ! -e "/run/snapd.socket" ] \
+                && [ ! "$(ls -A /var/lib/lxd/containers)" ] \
+                && [ ! "$(ls -A /var/lib/lxd/images)" ] \
+                && [ ! "$(ls -A /var/lib/lxd/networks)" ] \
+                && [ ! "$(ls -A /var/lib/lxd/storage-pools)" ]
+            then
+                echo "===> System doesn't have working snapd and LXD was never used, skipping"
                 SKIP=true
                 break
             fi

--- a/debian/lxd.preinst
+++ b/debian/lxd.preinst
@@ -1,6 +1,20 @@
 #!/bin/sh
 set -e
 
+function snapd_lxd_checker {
+    if [ ! -e "/run/snapd.socket" ] && [ ! -e "/var/lib/lxd/server.crt" ]; then
+        return 0
+    elif ( [ ! -e "/run/snapd.socket" ] \
+    && [ -z "$(ls -A /var/lib/lxd/containers >/dev/null 2>&1)" ] \
+    && [ -z "$(ls -A /var/lib/lxd/images >/dev/null 2>&1)" ] \
+    && [ -z "$(ls -A /var/lib/lxd/networks >/dev/null 2>&1)" ] \
+    && [ -z "$(ls -A /var/lib/lxd/storage-pools >/dev/null 2>&1)" ] ); then
+        return 0
+    else
+        return 1
+    fi
+}
+
 case "$1" in
     install|upgrade)
         . /usr/share/debconf/confmodule
@@ -23,13 +37,7 @@ case "$1" in
         COUNT=0
         SKIP=false
         while :; do
-            if ( [ ! -e "/run/snapd.socket" ] && [ ! -e "/var/lib/lxd/server.crt" ] ) \
-                || ( [ ! -e "/run/snapd.socket" ] \
-                && [ -z "$(ls -A /var/lib/lxd/containers >/dev/null 2>&1)" ] \
-                && [ -z "$(ls -A /var/lib/lxd/images >/dev/null 2>&1)" ] \
-                && [ -z "$(ls -A /var/lib/lxd/networks >/dev/null 2>&1)" ] \
-                && [ -z "$(ls -A /var/lib/lxd/storage-pools >/dev/null 2>&1)" ] )
-            then
+            if snapd_lxd_checker ; then
                 echo "===> System doesn't have working snapd and LXD was never used, skipping"
                 SKIP=true
                 break

--- a/debian/lxd.preinst
+++ b/debian/lxd.preinst
@@ -4,12 +4,41 @@ set -e
 function snapd_lxd_checker {
     if [ ! -e "/run/snapd.socket" ] && [ ! -e "/var/lib/lxd/server.crt" ]; then
         return 0
-    elif ( [ ! -e "/run/snapd.socket" ] \
-    && [ -z "$(ls -A /var/lib/lxd/containers >/dev/null 2>&1)" ] \
-    && [ -z "$(ls -A /var/lib/lxd/images >/dev/null 2>&1)" ] \
-    && [ -z "$(ls -A /var/lib/lxd/networks >/dev/null 2>&1)" ] \
-    && [ -z "$(ls -A /var/lib/lxd/storage-pools >/dev/null 2>&1)" ] ); then
-        return 0
+    elif [ ! -e "/run/snapd.socket" ]; then
+        CHECKERCOUNT=0
+        if [ -d "/var/lib/lxd/containers" ] ; then 
+            if [ -z "$(ls -A /var/lib/lxd/containers)" ]; then
+                CHECKERCOUNT=$((CHECKERCOUNT+1))
+            fi
+        else
+            CHECKERCOUNT=$((CHECKERCOUNT+1))
+        fi
+        if [ -d "/var/lib/lxd/images" ] ; then 
+            if [ -z "$(ls -A /var/lib/lxd/images)" ]; then
+                CHECKERCOUNT=$((CHECKERCOUNT+1))
+            fi
+        else
+            CHECKERCOUNT=$((CHECKERCOUNT+1))
+        fi
+        if [ -d "/var/lib/lxd/networks" ] ; then 
+            if [ -z "$(ls -A /var/lib/lxd/networks)" ]; then
+                CHECKERCOUNT=$((CHECKERCOUNT+1))
+            fi
+        else
+            CHECKERCOUNT=$((CHECKERCOUNT+1))
+        fi
+        if [ -d "/var/lib/lxd/storage-pools" ] ; then 
+            if [ -z "$(ls -A /var/lib/lxd/storage-pools)" ]; then
+                CHECKERCOUNT=$((CHECKERCOUNT+1))
+            fi
+        else
+            CHECKERCOUNT=$((CHECKERCOUNT+1))
+        fi
+        if [ "$CHECKERCOUNT" -eq 4 ]; then
+            return 0
+        else
+            return 1
+        fi
     else
         return 1
     fi


### PR DESCRIPTION
This solves [LP #1862550](https://bugs.launchpad.net/ubuntuwsl/+bug/1862550) by skipping directly if it detects that it is using WSL. 

The reason for doing this is that WSL does not support snap, and:

1. to reduce the confusion for WSL users who tries to update; and
2. to prevent the issue of broken dependencies during the upgrade to Ubuntu 20.04 LTS on WSL.

The last PR does not have a sign-off so I re-opened one.

Signed-off-by: Jinming Wu, Patrick <me@patrickwu.space>